### PR TITLE
Target JVM 1.6 explicitly (also scala 2.10.2)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ scmInfo := Some(
 )
 
 /* scala versions and options */
-scalaVersion := "2.10.1"
+scalaVersion := "2.10.2"
 
 // These options will be used for *all* versions.
 scalacOptions ++= Seq(
@@ -34,6 +34,8 @@ scalacOptions ++= Seq(
   "-Yclosure-elim",
   "-Yinline"
 )
+
+scalacOptions += "-target:jvm-1.6"
 
 // These language flags will be used only for 2.10.x.
 // Uncomment those you need, or if you hate SIP-18, all of them.


### PR DESCRIPTION
0.6.3 requires JVM 1.7 unnecessarily (probably because it was compiled with JDK 1.7).  This change targets 1.6 or later regardless of what version is used to compile it. Also upgrades to latest scala, 2.10.2.
