### PR TITLE
Fixed the Right case of Either in EitherDeserializer. TreeTraversingPars...

### DIFF
--- a/src/main/scala/com/codahale/jerkson/deser/EitherDeserializer.scala
+++ b/src/main/scala/com/codahale/jerkson/deser/EitherDeserializer.scala
@@ -10,7 +10,7 @@ class EitherDeserializer(config: DeserializationConfig,
     val node = jp.readValueAsTree[JsonNode]
 
     try {
-    val tp = new TreeTraversingParser(node, jp.getCodec)
+      val tp = new TreeTraversingParser(node, jp.getCodec)
       Left(tp.getCodec.readValue[Object](tp, javaType.containedType(0)))
     } catch {
       case _: Throwable => {

--- a/src/main/scala/com/codahale/jerkson/deser/EitherDeserializer.scala
+++ b/src/main/scala/com/codahale/jerkson/deser/EitherDeserializer.scala
@@ -8,12 +8,15 @@ class EitherDeserializer(config: DeserializationConfig,
                          javaType: JavaType) extends JsonDeserializer[Object] {
   def deserialize(jp: JsonParser, ctxt: DeserializationContext) = {
     val node = jp.readValueAsTree[JsonNode]
-    val tp = new TreeTraversingParser(node, jp.getCodec)
 
     try {
+    val tp = new TreeTraversingParser(node, jp.getCodec)
       Left(tp.getCodec.readValue[Object](tp, javaType.containedType(0)))
     } catch {
-      case _: Throwable => Right(tp.getCodec.readValue[Object](tp, javaType.containedType(1)))
+      case _: Throwable => {
+        val tp = new TreeTraversingParser(node, jp.getCodec)
+        Right(tp.getCodec.readValue[Object](tp, javaType.containedType(1)))
+      }
     }
   }
 


### PR DESCRIPTION
Deserializer for Either was not working for the Right case because it was trying to read from TreeTraversingParser twice without resetting it.  This fixes the problem. 
